### PR TITLE
Fix scroll bar overlap issue

### DIFF
--- a/.theme/wysiwyg.css
+++ b/.theme/wysiwyg.css
@@ -35,8 +35,8 @@ but mostly in terms of size / width / margins and visual shifts
 Editor */
 
 .markdown-source-view.mod-cm5 {
-  padding-left: 0;
-  padding-right: 0;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
 }
 
 /* to be concise between Editor and Preview we need to account for scrollbar */
@@ -54,8 +54,8 @@ Editor */
 }
 
 .CodeMirror-scroll {
-  padding-left: 4.5rem;
-  padding-right: 4.5rem;
+  padding-left: 3rem;
+  padding-right: 3rem;
   margin-right: 0;
   margin-bottom: 0;
 }

--- a/.theme/wysiwyg.css
+++ b/.theme/wysiwyg.css
@@ -87,13 +87,3 @@ Preview */
 .markdown-preview-view.is-readable-line-width .markdown-preview-section > div {
   width: var(--readable-line-length);
 }
-
-/*----------------------------------------------------------------
-Long tables should go underneath v-scrollbar */
-
-.CodeMirror-vscrollbar,
-.CodeMirror-hscrollbar,
-.CodeMirror-scrollbar-filler,
-.CodeMirror-gutter-filler {
-  z-index: 999;
-}


### PR DESCRIPTION
More permanent fix for #35, on top of #39

Before:

<img width="285" alt="Screenshot 2021-03-17 at 13 23 15" src="https://user-images.githubusercontent.com/349850/111476405-08bc5780-8726-11eb-940e-2b5ac0ef409f.png">

After:
<img width="586" alt="Screenshot 2021-03-17 at 13 38 05" src="https://user-images.githubusercontent.com/349850/111476472-1a9dfa80-8726-11eb-9efc-c5d99272ad29.png">
